### PR TITLE
fix: harden API quality and add tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Compile Python files
+        run: python -m compileall -q src tests
+
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -v

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -31,7 +31,14 @@ jobs:
           import json
 
           migration_file = os.environ["MIGRATION_FILE"]
-          sql_path = Path("sql/migrations") / migration_file
+          migrations_dir = Path("sql/migrations").resolve()
+          sql_path = (migrations_dir / migration_file).resolve()
+
+          try:
+              sql_path.relative_to(migrations_dir)
+          except ValueError:
+              print(f"ERROR: Migration path escapes sql/migrations: {migration_file}", file=sys.stderr)
+              sys.exit(1)
 
           if not sql_path.exists():
               print(f"ERROR: Migration file not found: {sql_path}", file=sys.stderr)

--- a/README.md
+++ b/README.md
@@ -179,7 +179,12 @@ To enable the daily GitHub Actions pipeline, add `SUPABASE_URL` and `SUPABASE_KE
 ### 4. Run the API locally
 ```bash
 pip install -r requirements.txt
-uvicorn src.api:app --reload
+PYTHONPATH=src uvicorn api:app --reload
+```
+
+PowerShell:
+```powershell
+$env:PYTHONPATH="src"; uvicorn api:app --reload
 ```
 
 ### 5. Deploy the API container

--- a/src/api.py
+++ b/src/api.py
@@ -26,9 +26,12 @@ from db import get_supabase
 _MODELS_PER_TAG = LIMIT_PER_TAG + 50
 # config.py の TARGET_PIPELINE_TAGS から自動計算（手動同期不要）
 _N_PIPELINE_TAGS = len(TARGET_PIPELINE_TAGS)
-# LIMIT_PER_TAG(200) × N_PIPELINE_TAGS(4) × days(25) 相当の絶対上限
-# 上限超えは trending 精度の低下と引き換えに DB 負荷を抑制する
-_ROW_CAP_MAX = 20_000
+# Supabase/PostgREST は 1 回のレスポンスで返る行数に上限があるため、
+# trending では明示的に range ページングする。90 日 × 4 タグ × 250 件/日
+# 程度を想定した安全上限。これを超える場合は不完全なランキングを返さず
+# 503 として運用者に row cap / 集計方法の見直しを促す。
+_PAGE_SIZE = 1000
+_TRENDING_HARD_ROW_CAP = 100_000
 
 app = FastAPI(
     title="HuggingFace Daily Insights API",
@@ -65,23 +68,30 @@ def get_trending(
     # pipeline_tag 指定なし = 全タグが対象。タグ数分のモデルを見込んで行数上限を設定
     # days × (1タグのモデル数上限) × (対象タグ数) でウィンドウ内の全スナップを取得できる
     tag_multiplier = 1 if pipeline_tag else _N_PIPELINE_TAGS
-    row_cap = min(days * _MODELS_PER_TAG * tag_multiplier, _ROW_CAP_MAX)
+    estimated_rows = days * _MODELS_PER_TAG * tag_multiplier
+    row_cap = min(max(estimated_rows, _PAGE_SIZE), _TRENDING_HARD_ROW_CAP)
 
     query = (
         sb.table("model_snapshots")
         .select("model_id, snapshot_date, likes, pipeline_tag")
         .gte("snapshot_date", cutoff)
         .order("snapshot_date", desc=False)
-        .limit(row_cap)
     )
     if pipeline_tag:
         query = query.eq("pipeline_tag", pipeline_tag)
 
     try:
-        resp = query.execute()
+        rows = _fetch_range_pages(query, max_rows=row_cap + 1)
     except Exception as e:
         raise HTTPException(status_code=503, detail="Database unavailable") from e
-    rows = resp.data
+    if len(rows) > row_cap:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Trending query exceeded safe row cap; reduce days/pipeline_tag "
+                "or move aggregation into the database"
+            ),
+        )
 
     # model_id ごとにスナップショットをまとめて likes の増分（最新 - 最古）を計算
     model_snapshots: dict[str, list] = defaultdict(list)
@@ -106,6 +116,29 @@ def get_trending(
 
     deltas.sort(key=lambda x: x["likes_delta"], reverse=True)
     return deltas[:limit]
+
+
+def _fetch_range_pages(query, max_rows: int) -> list[dict]:
+    """
+    Supabase query builder を range ページングで取得する。
+
+    PostgREST はサーバ側上限により `.limit(n)` だけでは大きい窓の全件が
+    返らないことがあるため、trending のように時系列窓全体が必要な用途では
+    明示的にページングする。
+    """
+    rows: list[dict] = []
+    offset = 0
+    while offset < max_rows:
+        upper = min(offset + _PAGE_SIZE - 1, max_rows - 1)
+        resp = query.range(offset, upper).execute()
+        page = resp.data or []
+        if not page:
+            break
+        rows.extend(page)
+        if len(page) < _PAGE_SIZE:
+            break
+        offset += _PAGE_SIZE
+    return rows
 
 
 @app.get("/models/new")

--- a/src/crawl_arxiv.py
+++ b/src/crawl_arxiv.py
@@ -51,6 +51,9 @@ def fetch_arxiv_papers(category: str, limit: int = PAPERS_PER_CATEGORY) -> list[
     except requests.RequestException as e:
         logger.error(f"arXiv API fetch failed for {category}: {e}")
         return []
+    except ET.ParseError as e:
+        logger.error(f"arXiv API returned invalid XML for {category}: {e}")
+        return []
 
 
 def _parse_arxiv_xml(xml_text: str) -> list[dict]:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,124 @@
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+sys.path.insert(0, str(SRC))
+
+import api  # noqa: E402
+
+
+class FakeSnapshotsQuery:
+    def __init__(self, rows):
+        self.rows = rows
+        self.ranges = []
+        self.pipeline_tag = None
+
+    def select(self, *_args, **_kwargs):
+        return self
+
+    def gte(self, *_args, **_kwargs):
+        return self
+
+    def order(self, *_args, **_kwargs):
+        return self
+
+    def eq(self, _column, value):
+        self.pipeline_tag = value
+        return self
+
+    def range(self, start, end):
+        self.ranges.append((start, end))
+        self._start = start
+        self._end = end
+        return self
+
+    def execute(self):
+        rows = self.rows
+        if self.pipeline_tag:
+            rows = [row for row in rows if row["pipeline_tag"] == self.pipeline_tag]
+        return SimpleNamespace(data=rows[self._start : self._end + 1])
+
+
+class FakeSupabase:
+    def __init__(self, rows):
+        self.query = FakeSnapshotsQuery(rows)
+
+    def table(self, name):
+        assert name == "model_snapshots"
+        return self.query
+
+
+class TrendingTests(unittest.TestCase):
+    def test_trending_fetches_all_pages_before_ranking(self):
+        rows = []
+        for i in range(api._PAGE_SIZE + 2):
+            model_id = f"org/model-{i}"
+            rows.append(
+                {
+                    "model_id": model_id,
+                    "snapshot_date": "2026-04-01",
+                    "likes": 1,
+                    "pipeline_tag": "text-generation",
+                }
+            )
+            rows.append(
+                {
+                    "model_id": model_id,
+                    "snapshot_date": "2026-04-22",
+                    "likes": i,
+                    "pipeline_tag": "text-generation",
+                }
+            )
+        # The best model is beyond the first PostgREST-sized page; without
+        # explicit pagination this would be invisible to the endpoint.
+        fake_sb = FakeSupabase(rows)
+
+        with patch.object(api, "get_supabase", return_value=fake_sb):
+            result = api.get_trending(
+                pipeline_tag="text-generation",
+                days=30,
+                limit=1,
+            )
+
+        self.assertEqual(result[0]["model_id"], f"org/model-{api._PAGE_SIZE + 1}")
+        self.assertGreater(len(fake_sb.query.ranges), 1)
+
+    def test_fetch_range_pages_allows_exact_cap_without_false_overflow(self):
+        rows = [{"model_id": "m", "pipeline_tag": "text-generation"}] * api._PAGE_SIZE
+        query = FakeSnapshotsQuery(rows)
+
+        fetched = api._fetch_range_pages(query, max_rows=api._PAGE_SIZE + 1)
+
+        self.assertEqual(len(fetched), api._PAGE_SIZE)
+        self.assertEqual(query.ranges[-1], (api._PAGE_SIZE, api._PAGE_SIZE))
+
+    def test_trending_rejects_overflow_instead_of_returning_partial_ranking(self):
+        rows = []
+        for i in range(api._PAGE_SIZE + 1):
+            rows.append(
+                {
+                    "model_id": f"org/model-{i}",
+                    "snapshot_date": "2026-04-01",
+                    "likes": 1,
+                    "pipeline_tag": "text-generation",
+                }
+            )
+        fake_sb = FakeSupabase(rows)
+
+        with patch.object(api, "_TRENDING_HARD_ROW_CAP", api._PAGE_SIZE), patch.object(
+            api, "get_supabase", return_value=fake_sb
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                api.get_trending(pipeline_tag="text-generation", days=30, limit=1)
+
+        self.assertEqual(ctx.exception.status_code, 503)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_crawl_arxiv.py
+++ b/tests/test_crawl_arxiv.py
@@ -1,0 +1,24 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+sys.path.insert(0, str(SRC))
+
+import crawl_arxiv  # noqa: E402
+
+
+class ArxivFetchTests(unittest.TestCase):
+    def test_invalid_xml_returns_empty_list(self):
+        response = Mock()
+        response.text = "<feed><entry>"
+        response.raise_for_status.return_value = None
+
+        with patch.object(crawl_arxiv.requests, "get", return_value=response):
+            self.assertEqual(crawl_arxiv.fetch_arxiv_papers("cs.AI"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- page `/models/trending` Supabase reads instead of relying on a single capped query
- add invalid XML handling for arXiv fetches
- guard migration workflow paths against escaping `sql/migrations`
- fix README local uvicorn command and add PowerShell variant
- add CI plus unittest coverage for trending pagination and arXiv parse failures

## Verification
- `python -m compileall -q src tests`
- `python -m unittest discover -s tests -v`
- `git diff --check`

## Left as judgment call
- `crawl_arena.py` still loads upstream HF Space pickle. Fully mitigating this needs an ops/design decision: switch data source or isolate pickle parsing in a secretless job/container before DB writes.