### PR TITLE
ci: isolate arena pickle parsing in read-only job

### DIFF
--- a/.github/workflows/daily_crawl.yml
+++ b/.github/workflows/daily_crawl.yml
@@ -8,20 +8,54 @@ on:
   workflow_dispatch:
 
 permissions:
-  # Required for creating Releases (contents: write)
-  contents: write
+  contents: read
 
 jobs:
-  crawl:
+  arena-parse:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
+    permissions:
+      # This job parses upstream pickle data. Keep it read-only and do not pass
+      # repository secrets into any step in this job.
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
         with:
-          # Arena pickle parsing runs untrusted upstream pickle code; do not
-          # leave a write-capable Git credential in the workspace.
+          # Pickle parsing runs untrusted upstream code if the source is
+          # compromised; do not leave a git credential in the workspace.
           persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Parse Arena pickle to JSON (no secrets)
+        run: python src/crawl_arena.py --export-json arena_rankings_import.json
+
+      - name: Upload Arena JSON artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: arena-rankings-import
+          path: arena_rankings_import.json
+          if-no-files-found: error
+          retention-days: 1
+
+  crawl:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: arena-parse
+    permissions:
+      # Required for creating Releases.
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -44,8 +78,10 @@ jobs:
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
         run: python src/crawl_arxiv.py
 
-      - name: Parse Arena pickle to JSON (no Supabase secrets)
-        run: python src/crawl_arena.py --export-json arena_rankings_import.json
+      - name: Download Arena JSON artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: arena-rankings-import
 
       - name: Import Arena rankings JSON
         env:


### PR DESCRIPTION
## Summary
- move Arena pickle parsing into a separate `arena-parse` job
- keep that job read-only (`contents: read`), secretless, and `persist-credentials: false`
- pass normalized `arena_rankings_import.json` to the DB-writing job via a short-lived artifact
- keep the release/DB job as the only job with `contents: write` and Supabase secrets

## Verification
- `python -m compileall -q src tests`
- `python -m unittest discover -s tests -v`
- `git diff --check`

## Security note
This further reduces pickle blast radius versus a secretless step in the same job: compromised pickle code no longer runs in the job that receives Supabase secrets or release write permissions.