### PR TITLE
ci: enable GitHub Pages from workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - uses: actions/upload-pages-artifact@v3
         with:
           path: docs


### PR DESCRIPTION
## Summary
- set `enablement: true` on `actions/configure-pages`
- fixes the initial Pages deploy failure when the repository has not yet enabled Pages with GitHub Actions as the source

## Verification
- `node --check docs/app.js`
- `python -m unittest discover -s tests -v`
- `git diff --check`

## Context
The first Pages deployment failed at configure-pages because the repo did not have Pages enabled yet.