### PR TITLE
fix: cache-bust Pages dashboard assets

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
       name="description"
       content="Static dashboard for daily HuggingFace model, arXiv paper, and LMArena CSV snapshots."
     />
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="styles.css?v=20260422-bundled" />
   </head>
   <body>
     <main class="shell">
@@ -137,6 +137,6 @@
       </section>
     </main>
 
-    <script src="app.js"></script>
+    <script src="app.js?v=20260422-bundled"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add query-string cache busting to `styles.css` and `app.js`
- fixes browsers that still have the pre-bundled dashboard JavaScript cached and show `Unable to load release data`

## Verification
- `node --check docs/app.js`
- `python -m unittest discover -s tests -v`
- `git diff --check`

## Context
The live page works with the bundled-data JS, but user screenshot showed the old CORS-based JS was still cached in the browser.