### PR TITLE
docs: surface live dashboard links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 [![Daily Crawl](https://github.com/Tenormusica2024/huggingface-daily-insights-api/actions/workflows/daily_crawl.yml/badge.svg)](https://github.com/Tenormusica2024/huggingface-daily-insights-api/actions/workflows/daily_crawl.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
+- Live dashboard: <https://tenormusica2024.github.io/huggingface-daily-insights-api/>
+- Latest CSV release: <https://github.com/Tenormusica2024/huggingface-daily-insights-api/releases/latest>
+- Repository: <https://github.com/Tenormusica2024/huggingface-daily-insights-api>
+
 An open-source data pipeline that tracks HuggingFace trending models, arXiv AI/ML papers, and LMArena ELO rankings — storing daily snapshots so you can query **historical time-series data** that the upstream sources do not expose.
 
 **Free to self-host. Free to fork. Free to use the daily CSV dumps.**


### PR DESCRIPTION
## Summary
- add the live dashboard URL near the top of README
- also surface the latest CSV release link and repo link in the same top section

## Why
The dashboard now works publicly, so the README should expose the main entry points immediately instead of only later in the document.

## Verification
- `python -m unittest discover -s tests -v`
- `git diff --check`